### PR TITLE
Remove error throwing when an element isn't found

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -174,18 +174,6 @@ describe('queryAll', () => {
         expect((pageObject() as Element[])[1].textContent).to.equal('Two');
     });
 
-    it('returns undefined when it cant find the root element', async () => {
-        await fixture(html`
-            <div>
-                <div class="foo">One</div>
-                <div class="foo">Two</div>
-            </div>
-        `);
-        const schema = queryAll('.wont-find-me');
-        const pageObject = createPageObject(schema);
-        expect(pageObject()).to.equal(undefined);
-    });
-
     it('returns the expected child element', async () => {
         await fixture(html`
             <div>
@@ -203,7 +191,6 @@ describe('queryAll', () => {
         `);
         const schema = queryAll('.foo', {
             biz: queryAll('.biz'),
-            wontFindMe: queryAll('.wont-find-me'),
         });
         const pageObject = createPageObject(schema);
         // @ts-ignore
@@ -220,7 +207,5 @@ describe('queryAll', () => {
         expect(pageObject()[1].biz[0].textContent).to.equal('Three');
         // @ts-ignore
         expect(pageObject()[1].biz[1].textContent).to.equal('Four');
-        // @ts-ignore
-        expect(pageObject().wontFindMe).to.equal(undefined);
     });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -127,6 +127,17 @@ describe('query', () => {
         expect((pageObject() as Element).textContent).to.equal('Foo');
     });
 
+    it('returns undefined when it cant find the root element', async () => {
+        await fixture(html`
+            <div>
+                <div class="foo">Foo</div>
+            </div>
+        `);
+        const schema = query('.wont-find-me');
+        const pageObject = createPageObject(schema);
+        expect(pageObject()).to.equal(undefined);
+    });
+
     it('returns the expected child element', async () => {
         await fixture(html`
             <div>
@@ -138,10 +149,13 @@ describe('query', () => {
         `);
         const schema = query('.foo', {
             biz: query('.biz'),
+            wontFindMe: query('.wont-find-me'),
         });
         const pageObject = createPageObject(schema);
         // @ts-ignore
         expect(pageObject.biz.textContent).to.equal('This');
+        // @ts-ignore
+        expect(pageObject.wontFindMe).to.equal(undefined);
     });
 });
 
@@ -158,6 +172,18 @@ describe('queryAll', () => {
         expect((pageObject() as Element[]).length).to.equal(2);
         expect((pageObject() as Element[])[0].textContent).to.equal('One');
         expect((pageObject() as Element[])[1].textContent).to.equal('Two');
+    });
+
+    it('returns undefined when it cant find the root element', async () => {
+        await fixture(html`
+            <div>
+                <div class="foo">One</div>
+                <div class="foo">Two</div>
+            </div>
+        `);
+        const schema = queryAll('.wont-find-me');
+        const pageObject = createPageObject(schema);
+        expect(pageObject()).to.equal(undefined);
     });
 
     it('returns the expected child element', async () => {
@@ -177,6 +203,7 @@ describe('queryAll', () => {
         `);
         const schema = queryAll('.foo', {
             biz: queryAll('.biz'),
+            wontFindMe: queryAll('.wont-find-me'),
         });
         const pageObject = createPageObject(schema);
         // @ts-ignore
@@ -193,5 +220,7 @@ describe('queryAll', () => {
         expect(pageObject()[1].biz[0].textContent).to.equal('Three');
         // @ts-ignore
         expect(pageObject()[1].biz[1].textContent).to.equal('Four');
+        // @ts-ignore
+        expect(pageObject().wontFindMe).to.equal(undefined);
     });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,12 +17,12 @@ function createElementProxy(element: Element, children: Children = {}): Element 
     });
 }
 
-function resolveElement(el: Element, mode: Mode, selector: string, children?: Children): Element | Element[] {
+function resolveElement(el: Element, mode: Mode, selector: string, children?: Children): QueryResult {
     switch (mode) {
         case 'Query':
             const element = el.querySelector(selector);
             if (!element) {
-                throw new Error('Element not found');
+                return undefined;
             }
             return createElementProxy(element, children);
         case 'QueryAll':
@@ -34,7 +34,7 @@ function resolveElement(el: Element, mode: Mode, selector: string, children?: Ch
 
 
 function createElementResolver(mode: Mode, selector: string, children?: Children) {
-    return function(el?: Element): Element | Element[] {
+    return function(el?: Element): QueryResult {
         return resolveElement(el ?? document.body, mode, selector, children);
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,11 +5,13 @@ type Mode = Query | QueryAll;
 type Children = Record<string, Schema>;
 type Scope = [Mode, string];
 
+type QueryResult = undefined | Element | Element[];
+
 interface Schema {
     scope: Scope;
     children?: Children;
 }
 
 interface PageObject {
-    (el?: Element): Element | Element[]
+    (el?: Element): QueryResult;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,8 @@
 type Query = 'Query';
 type QueryAll = 'QueryAll';
 type Mode = Query | QueryAll;
-
 type Children = Record<string, Schema>;
 type Scope = [Mode, string];
-
 type QueryResult = undefined | Element | Element[];
 
 interface Schema {


### PR DESCRIPTION
When testing the library it became apparent rather quickly that it was annoying to assert when an element was not in the DOM. Removing the error throwing for now while I test further.